### PR TITLE
Two bug fixes (isIE and isMobile)

### DIFF
--- a/src/ua.js
+++ b/src/ua.js
@@ -71,7 +71,7 @@ var UA = (function (window, navigator) {
          *
          * @method isMobile
          */
-        isMobile: detect(/(iphone|ipod|(android.*?mobile)|blackberry|nokia)/i),
+        isMobile: detect(/(iphone|ipod|((?:android)?.*?mobile)|blackberry|nokia)/i),
 
         /**
          * Return true if we are running on Opera.


### PR DESCRIPTION
As seen in the demo on master, there's a bug in `UA.isIE`--it just returns a function, which is truthy so anything that isn't Chrome will be reported as IE (just because this test comes after Chrome). Also, your `isMobile` test fails for any non-Android browser with a `Mobile` token, e.g., Firefox OS.
