### PR TITLE
Better detection for Tablet UAs.

### DIFF
--- a/src/ua.js
+++ b/src/ua.js
@@ -97,7 +97,7 @@ var UA = (function (window, navigator) {
          *
          * @method isTablet
          */
-        isTablet: detect(/(ipad|android(?!.*mobile))/i),
+        isTablet: detect(/(ipad|android(?!.*mobile)|tablet)/i),
 
         /**
          * Return true if the browser is running on a TV!


### PR DESCRIPTION
This change allows you to correctly detect the following browsers as tablets:

Firefox OS tablet: 
`Mozilla/5.0 (Tablet; rv:29.0) Gecko/29.0 Firefox/29.0`

Blackberry Playbook: 
`Mozilla/5.0 (PlayBook; U; RIM Tablet OS 2.0.1; en-US) AppleWebKit/535.8+ (KHTML, like Gecko) Version/7.2.0.1 Safari/535.8+`

Opera Mobile (running as tablet): 
`Opera/9.80 (Android 2.2.2; Linux; Opera Tablet/ADR-1111101157; U; en) Presto/2.9.201 Version/11.50`
