### PR TITLE
Add support for nodejs module.exports

### DIFF
--- a/src/ua.js
+++ b/src/ua.js
@@ -163,6 +163,9 @@
         define( [], function() {
             return UA;
         } );
+    } else if (typeof module !== 'undefined' && module.exports) {
+        module.exports = UA.attach;
+        module.exports.UA = UA;
     } else {
         // browser global
         window.UA = UA;


### PR DESCRIPTION
Add support for nodejs module.exports. This code enable to use a node-style `require()` to call your browser code and load modules installed by `npm`.
